### PR TITLE
feat: UI improvements for nav, images, and project cards

### DIFF
--- a/components/blogs/blog-box/blog-box.js
+++ b/components/blogs/blog-box/blog-box.js
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import Image from "next/image";
 import classes from "./blog-box.module.scss";
 
 const BlogBox = ({ post }) => {
@@ -15,11 +16,12 @@ const BlogBox = ({ post }) => {
   return (
     <div className={classes.post}>
       <Link className={classes.image} href={`/articles/${postId}`}>
-        <img
+        <Image
           src={imagePath}
           alt={`Cover picture to the article "${title}".`}
-          width={600}
-          height={300}
+          fill
+          sizes="(min-width: 768px) 50vw, 100vw"
+          style={{ objectFit: "cover", objectPosition: "center" }}
         />
       </Link>
       <div className={classes.description}>

--- a/components/blogs/blog-box/blog-box.module.scss
+++ b/components/blogs/blog-box/blog-box.module.scss
@@ -7,16 +7,11 @@
   padding: 0 0 10px 0;
   .image {
     display: block;
+    position: relative;
     width: 100%;
     height: 400px;
     overflow: hidden;
     border-radius: 1em 1em 0 0;
-    img {
-      object-fit: cover;
-      object-position: middle;
-      width: 100%;
-      height: 100%;
-    }
   }
 
   .description {

--- a/components/home/featured-post-box/featured-post-box.js
+++ b/components/home/featured-post-box/featured-post-box.js
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import Image from "next/image";
 import classes from "./featured-post.box.module.scss";
 
 const FeaturedPostBox = ({ post }) => {
@@ -9,20 +10,16 @@ const FeaturedPostBox = ({ post }) => {
     year: "numeric",
   });
 
-  const loaderProp = ({ src }) => {
-    return src;
-  };
-
   const imagePath = post.thumbnail;
   return (
     <div className={classes.post}>
       <div className={classes.image}>
-        <img
+        <Image
           src={imagePath}
           alt={`Cover picture to the article "${title}".`}
-          width={100}
-          height={150}
-          // loader={loaderProp}
+          fill
+          sizes="(min-width: 768px) 300px, 100vw"
+          style={{ objectFit: "cover", objectPosition: "center" }}
         />
       </div>
       <div className={classes.description}>

--- a/components/home/featured-post-box/featured-post.box.module.scss
+++ b/components/home/featured-post-box/featured-post.box.module.scss
@@ -4,15 +4,10 @@
     margin: 30px 0;
     .image{
         display: block;
-        max-height: 300px;
+        position: relative;
+        height: 250px;
         overflow: hidden;
         border-radius: 10px;
-        img {
-            object-fit: cover;
-            object-position: middle;
-            width: 100%;
-            height: 100%;
-          }
     }
     a {
         font-style: normal;

--- a/components/layout/hamburger/hamburger.js
+++ b/components/layout/hamburger/hamburger.js
@@ -1,12 +1,17 @@
 import classes from "./hamburger.module.scss";
 
-const Hamburger = ({ onClick }) => {
+const Hamburger = ({ onClick, isOpen }) => {
   return (
-    <div className={classes.hamburger} onClick={onClick}>
+    <button
+      className={`${classes.hamburger} ${isOpen ? classes.open : ""}`}
+      onClick={onClick}
+      aria-label={isOpen ? "Close navigation menu" : "Open navigation menu"}
+      aria-expanded={isOpen}
+    >
       <span></span>
       <span></span>
       <span></span>
-    </div>
+    </button>
   );
 };
 

--- a/components/layout/hamburger/hamburger.module.scss
+++ b/components/layout/hamburger/hamburger.module.scss
@@ -1,9 +1,11 @@
 @use '/styles/variables' as v;
 
-
 .hamburger {
     display: inline-block;
-    right: 0;
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
 
     span {
         display: block;
@@ -11,11 +13,25 @@
         height: 3px;
         background-color: v.$light-color;
         margin: 5px 0;
+        transition: transform 0.3s ease, opacity 0.3s ease;
+        transform-origin: center;
+    }
+
+    &.open {
+        span:nth-child(1) {
+            transform: translateY(8px) rotate(45deg);
+        }
+        span:nth-child(2) {
+            opacity: 0;
+            transform: translateX(-8px);
+        }
+        span:nth-child(3) {
+            transform: translateY(-8px) rotate(-45deg);
+        }
     }
 }
 
 @media only screen and (min-width: 768px) {
-
     .hamburger {
         display: none;
     }

--- a/components/layout/main-navigation.module.scss
+++ b/components/layout/main-navigation.module.scss
@@ -41,9 +41,18 @@
     margin: 0;
     padding: 0;
     gap: 0.25rem;
+    max-height: 0;
+    overflow: hidden;
+    opacity: 0;
+    transition: max-height 0.3s ease, opacity 0.25s ease;
 
     li {
       margin: 10px 0 0 0;
+    }
+
+    &.mobile_navlinks_open {
+      max-height: 300px;
+      opacity: 1;
     }
   }
 }
@@ -51,7 +60,7 @@
 @media (min-width: 768px) {
   .header {
     height: 6rem;
-    padding: 0px 200px;
+    padding: 0 clamp(20px, 10vw, 200px);
     justify-content: space-between;
     flex-direction: row;
     align-items: center;

--- a/components/layout/mobile-navigation.js
+++ b/components/layout/mobile-navigation.js
@@ -19,48 +19,48 @@ const MobileNavigation = () => {
   }, [pathName]);
   return (
     <Fragment>
-      <Hamburger onClick={navBarToggleHandler} />
-      {isNavOpen && (
-        <ul className={classes.mobile_navlinks}>
-          <li>
-            <Link className={pathName === "/" ? classes.active : ""} href="/">
-              Home
-            </Link>
-          </li>
-          <li>
-            <Link
-              className={pathName === "/about" ? classes.active : ""}
-              href="/about"
-            >
-              About
-            </Link>
-          </li>
-          <li>
-            <Link
-              className={pathName === "/projects" ? classes.active : ""}
-              href="/projects"
-            >
-              Projects
-            </Link>
-          </li>
-          <li>
-            <Link
-              className={pathName === "/articles" ? classes.active : ""}
-              href="/articles"
-            >
-              Articles
-            </Link>
-          </li>
-          <li>
-            <Link
-              className={pathName === "/contact" ? classes.active : ""}
-              href="/contact"
-            >
-              Contact
-            </Link>
-          </li>
-        </ul>
-      )}
+      <Hamburger onClick={navBarToggleHandler} isOpen={isNavOpen} />
+      <ul
+        className={`${classes.mobile_navlinks} ${isNavOpen ? classes.mobile_navlinks_open : ""}`}
+      >
+        <li>
+          <Link className={pathName === "/" ? classes.active : ""} href="/">
+            Home
+          </Link>
+        </li>
+        <li>
+          <Link
+            className={pathName === "/about" ? classes.active : ""}
+            href="/about"
+          >
+            About
+          </Link>
+        </li>
+        <li>
+          <Link
+            className={pathName === "/projects" ? classes.active : ""}
+            href="/projects"
+          >
+            Projects
+          </Link>
+        </li>
+        <li>
+          <Link
+            className={pathName === "/articles" ? classes.active : ""}
+            href="/articles"
+          >
+            Articles
+          </Link>
+        </li>
+        <li>
+          <Link
+            className={pathName === "/contact" ? classes.active : ""}
+            href="/contact"
+          >
+            Contact
+          </Link>
+        </li>
+      </ul>
     </Fragment>
   );
 };

--- a/components/projects/project-box/project-box.js
+++ b/components/projects/project-box/project-box.js
@@ -1,4 +1,3 @@
-import { Link } from "lucide-react";
 import classes from "./project-box.module.scss";
 
 const ProjectBox = ({ project }) => {

--- a/components/projects/project-box/project-box.module.scss
+++ b/components/projects/project-box/project-box.module.scss
@@ -4,6 +4,13 @@
   background-color: v.$light-color;
   padding: 20px;
   border-radius: 5px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+  &:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+  }
+
   h2 {
     font-size: v.$size-5;
     margin: 0 0 10px 0;


### PR DESCRIPTION
- Hamburger now animates to an X on open (span rotation + fade), converted to semantic <button> with aria-label/aria-expanded, and mobile nav slides in with max-height/opacity transition
- Replace plain <img> with Next.js <Image fill> in featured-post-box and blog-box for lazy loading and optimised delivery
- Project cards lift on hover via transform + box-shadow transition; remove unused lucide-react import
- Fix hardcoded nav desktop padding (200px → clamp(20px, 10vw, 200px))